### PR TITLE
Fix emote encoding XMLHttpRequest requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/test/packetLog.txt
 packetLog.txt
 src/test/cred.txt
 *.map
+*~

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -204,7 +204,7 @@ var Client = (function () {
                     var endIndex = content.indexOf("function ParseEmoteOutput()");
                     assert.ok(startIndex !== -1 && endIndex !== -1 && startIndex < endIndex, "mfccore.js layout has changed, don't know what to do now");
                     content = content.substr(startIndex, endIndex - startIndex);
-                    content = "var document = {cookie: ''};var XMLHttpRequest = require('XMLHttpRequest').XMLHttpRequest;function bind(that,f){return f.bind(that);}" + content.replace(/createRequestObject\(\)/g, "new XMLHttpRequest()").replace(/new MfcImageHost\(\)/g, "{host: function(){return '';}}").replace(/this\.Reset\(\);/g, "this.Reset();this.oReq = new XMLHttpRequest();");
+                    content = "var document = {cookie: ''};var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;function bind(that,f){return f.bind(that);}" + content.replace(/createRequestObject\(\)/g, "new XMLHttpRequest()").replace(/new MfcImageHost\(\)/g, "{host: function(){return '';}}").replace(/this\.Reset\(\);/g, "this.Reset();this.oReq = new XMLHttpRequest();");
                     return content;
                 }).then(function (obj) {
                     _this.emoteParser = new obj.ParseEmoteInput();

--- a/src/main/Client.ts
+++ b/src/main/Client.ts
@@ -381,7 +381,7 @@ export class Client implements EventEmitter {
                     content = content.substr(startIndex, endIndex - startIndex);
 
                     // Then massage the function somewhat and prepend some prerequisites
-                    content = "var document = {cookie: ''};var XMLHttpRequest = require('XMLHttpRequest').XMLHttpRequest;function bind(that,f){return f.bind(that);}" + content.replace(/createRequestObject\(\)/g, "new XMLHttpRequest()").replace(/new MfcImageHost\(\)/g, "{host: function(){return '';}}").replace(/this\.Reset\(\);/g, "this.Reset();this.oReq = new XMLHttpRequest();");
+                    content = "var document = {cookie: ''};var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;function bind(that,f){return f.bind(that);}" + content.replace(/createRequestObject\(\)/g, "new XMLHttpRequest()").replace(/new MfcImageHost\(\)/g, "{host: function(){return '';}}").replace(/this\.Reset\(\);/g, "this.Reset();this.oReq = new XMLHttpRequest();");
                     return content;
                 }).then((obj) => {
                     this.emoteParser = new obj.ParseEmoteInput();


### PR DESCRIPTION
Was working with this, and I kept getting an unhelpful error when trying to use emotes in sent messages.

`module.js:327
    throw err;
    ^`

Did some digging and saw this was being thrown while calling `ensureEmoteParserIsLoaded`

`Promise {
  <rejected> { [Error: Cannot find module 'XMLHttpRequest'] code: 'MODULE_NOT_FOUND' } }`

Making the requirement lowercase seems to fix the issue for me, I am able to send emotes.

